### PR TITLE
Add Terraform Agent Toolkit MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,250 +1,32 @@
-# Stripe Agent Toolkit
+# Terraform Agent Toolkit
 
-The Stripe Agent Toolkit enables popular agent frameworks including OpenAI's Agent SDK, LangChain, CrewAI, Vercel's AI SDK, and Model Context Protocol (MCP) to integrate with Stripe APIs through function calling. The
-library is not exhaustive of the entire Stripe API. It includes support for both Python and TypeScript and is built directly on top of the Stripe [Python][python-sdk] and [Node][node-sdk] SDKs.
+Minimal SDK inspired by Stripe's agent-toolkit for managing Terraform operations.
 
-Included below are basic instructions, but refer to the [Python](/python) and [TypeScript](/typescript) packages for more information.
-
-## Python
-
-### Installation
-
-You don't need this source code unless you want to modify the package. If you just
-want to use the package run:
-
-```sh
-pip install stripe-agent-toolkit
-```
-
-#### Requirements
-
-- Python 3.11+
-
-### Usage
-
-The library needs to be configured with your account's secret key which is
-available in your [Stripe Dashboard][api-keys].
-
-```python
-from stripe_agent_toolkit.openai.toolkit import StripeAgentToolkit
-
-stripe_agent_toolkit = StripeAgentToolkit(
-    secret_key="sk_test_...",
-    configuration={
-        "actions": {
-            "payment_links": {
-                "create": True,
-            },
-        }
-    },
-)
-```
-
-The toolkit works with OpenAI's Agent SDK, LangChain, and CrewAI and can be passed as a list of tools. For example:
-
-```python
-from agents import Agent
-
-stripe_agent = Agent(
-    name="Stripe Agent",
-    instructions="You are an expert at integrating with Stripe",
-    tools=stripe_agent_toolkit.get_tools()
-)
-```
-
-Examples for OpenAI's Agent SDK,LangChain, and CrewAI are included in [/examples](/python/examples).
-
-#### Context
-
-In some cases you will want to provide values that serve as defaults when making requests. Currently, the `account` context value enables you to make API calls for your [connected accounts](https://docs.stripe.com/connect/authentication).
-
-```python
-stripe_agent_toolkit = StripeAgentToolkit(
-    secret_key="sk_test_...",
-    configuration={
-        "context": {
-            "account": "acct_123"
-        }
-    }
-)
-```
-
-## TypeScript
-
-### Installation
-
-You don't need this source code unless you want to modify the package. If you just
-want to use the package run:
-
-```
-npm install @stripe/agent-toolkit
-```
-
-#### Requirements
-
-- Node 18+
-
-### Usage
-
-The library needs to be configured with your account's secret key which is available in your [Stripe Dashboard][api-keys]. Additionally, `configuration` enables you to specify the types of actions that can be taken using the toolkit.
-
-```typescript
-import { StripeAgentToolkit } from "@stripe/agent-toolkit/langchain";
-
-const stripeAgentToolkit = new StripeAgentToolkit({
-  secretKey: process.env.STRIPE_SECRET_KEY!,
-  configuration: {
-    actions: {
-      paymentLinks: {
-        create: true,
-      },
-    },
-  },
-});
-```
-
-#### Tools
-
-The toolkit works with LangChain and Vercel's AI SDK and can be passed as a list of tools. For example:
-
-```typescript
-import { AgentExecutor, createStructuredChatAgent } from "langchain/agents";
-
-const tools = stripeAgentToolkit.getTools();
-
-const agent = await createStructuredChatAgent({
-  llm,
-  tools,
-  prompt,
-});
-
-const agentExecutor = new AgentExecutor({
-  agent,
-  tools,
-});
-```
-
-#### Context
-
-In some cases you will want to provide values that serve as defaults when making requests. Currently, the `account` context value enables you to make API calls for your [connected accounts](https://docs.stripe.com/connect/authentication).
-
-```typescript
-const stripeAgentToolkit = new StripeAgentToolkit({
-  secretKey: process.env.STRIPE_SECRET_KEY!,
-  configuration: {
-    context: {
-      account: "acct_123",
-    },
-  },
-});
-```
-
-#### Metered billing
-
-For Vercel's AI SDK, you can use middleware to submit billing events for usage. All that is required is the customer ID and the input/output meters to bill.
-
-```typescript
-import { StripeAgentToolkit } from "@stripe/agent-toolkit/ai-sdk";
-import { openai } from "@ai-sdk/openai";
-import {
-  generateText,
-  experimental_wrapLanguageModel as wrapLanguageModel,
-} from "ai";
-
-const stripeAgentToolkit = new StripeAgentToolkit({
-  secretKey: process.env.STRIPE_SECRET_KEY!,
-  configuration: {
-    actions: {
-      paymentLinks: {
-        create: true,
-      },
-    },
-  },
-});
-
-const model = wrapLanguageModel({
-  model: openai("gpt-4o"),
-  middleware: stripeAgentToolkit.middleware({
-    billing: {
-      customer: "cus_123",
-      meters: {
-        input: "input_tokens",
-        output: "output_tokens",
-      },
-    },
-  }),
-});
-```
-
-## Model Context Protocol
-
-The Stripe Agent Toolkit also supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.com/).
-
-To run the Stripe MCP server using npx, use the following command:
+## Installation
 
 ```bash
-npx -y @stripe/mcp --tools=all --api-key=YOUR_STRIPE_SECRET_KEY
+pip install terraform_agent_toolkit
 ```
 
-Replace `YOUR_STRIPE_SECRET_KEY` with your actual Stripe secret key. Or, you could set the STRIPE_SECRET_KEY in your environment variables.
+## Quick Start
 
-Alternatively, you can set up your own MCP server. For example:
+```python
+from terraform_agent_toolkit import TerraformAgentToolkit
 
-```typescript
-import { StripeAgentToolkit } from "@stripe/agent-toolkit/modelcontextprotocol";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+allowed = [
+    "plan_infrastructure",
+    "apply_infrastructure",
+]
 
-const server = new StripeAgentToolkit({
-  secretKey: process.env.STRIPE_SECRET_KEY!,
-  configuration: {
-    actions: {
-      paymentLinks: {
-        create: true,
-      },
-      products: {
-        create: true,
-      },
-      prices: {
-        create: true,
-      },
-    },
-  },
-});
+tk = TerraformAgentToolkit(working_dir="./infra", allowed_actions=allowed)
+plan = tk.plan_infrastructure()
+print(plan["summary"])
 
-async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error("Stripe MCP Server running on stdio");
-}
-
-main().catch((error) => {
-  console.error("Fatal error in main():", error);
-  process.exit(1);
-});
+apply = tk.apply_infrastructure(confirm=True)
+print(apply["summary"])
 ```
 
-## Supported API methods
+## Safety
 
-- [Create a customer](https://docs.stripe.com/api/customers/create)
-- [List all customers](https://docs.stripe.com/api/customers/list)
-- [Create a coupon](https://docs.stripe.com/api/coupons/create)
-- [List all coupons](https://docs.stripe.com/api/coupons/list)
-- [Create a product](https://docs.stripe.com/api/products/create)
-- [List all products](https://docs.stripe.com/api/products/list)
-- [Create a price](https://docs.stripe.com/api/prices/create)
-- [List all prices](https://docs.stripe.com/api/prices/list)
-- [Create a payment link](https://docs.stripe.com/api/payment-link/create)
-- [Create an invoice](https://docs.stripe.com/api/invoices/create)
-- [Create an invoice item](https://docs.stripe.com/api/invoiceitems/create)
-- [Finalize an invoice](https://docs.stripe.com/api/invoices/finalize)
-- [Retrieve balance](https://docs.stripe.com/api/balance/balance_retrieve)
-- [List all subscriptions](https://docs.stripe.com/api/subscriptions/list)
-- [Update a subscription](https://docs.stripe.com/api/subscriptions/update)
-- [Cancel a subscription](https://docs.stripe.com/api/subscriptions/cancel)
-- [Create a refund](https://docs.stripe.com/api/refunds/create)
-- [List all disputes](https://docs.stripe.com/api/disputes/list)
-- [Update a dispute](https://docs.stripe.com/api/disputes/update)
-
-[python-sdk]: https://github.com/stripe/stripe-python
-[node-sdk]: https://github.com/stripe/stripe-node
-[api-keys]: https://dashboard.stripe.com/account/apikeys
+- Actions are whitelisted via `allowed_actions`.
+- Applying infrastructure requires explicit confirmation unless disabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "terraform_agent_toolkit"
+version = "0.1.0"
+description = "MVP SDK for managing Terraform via agent toolkit"
+authors = [ { name="OpenAI" } ]
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.optional-dependencies]
+langchain = ["langchain"]
+
+[tool.pytest.ini_options]
+addopts = "-vv"

--- a/terraform_agent_toolkit/__init__.py
+++ b/terraform_agent_toolkit/__init__.py
@@ -1,0 +1,7 @@
+"""terraform_agent_toolkit package."""
+
+from .exceptions import ActionNotAllowedError
+from .toolkit import TerraformAgentToolkit
+
+__all__ = ["TerraformAgentToolkit", "ActionNotAllowedError"]
+__version__ = "0.1.0"

--- a/terraform_agent_toolkit/core.py
+++ b/terraform_agent_toolkit/core.py
@@ -1,0 +1,26 @@
+import subprocess
+from typing import List, Optional, Dict
+
+MAX_OUTPUT_CHARS = 4000
+
+
+def run_terraform_command(cmd: List[str], cwd: str, env: Optional[Dict[str, str]] = None) -> dict:
+    """Run a Terraform CLI command and capture its output."""
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    combined = (stdout + "\n" + stderr).strip()
+    summary = combined[:MAX_OUTPUT_CHARS]
+    return {
+        "stdout": stdout,
+        "stderr": stderr,
+        "returncode": result.returncode,
+        "success": result.returncode == 0,
+        "summary": summary,
+    }

--- a/terraform_agent_toolkit/exceptions.py
+++ b/terraform_agent_toolkit/exceptions.py
@@ -1,0 +1,2 @@
+class ActionNotAllowedError(Exception):
+    """Raised when attempting to execute a disallowed action."""

--- a/terraform_agent_toolkit/langchain.py
+++ b/terraform_agent_toolkit/langchain.py
@@ -1,0 +1,30 @@
+from typing import List
+
+from langchain.tools import Tool
+
+from .toolkit import TerraformAgentToolkit
+
+
+TOOL_METHODS = [
+    "plan_infrastructure",
+    "apply_infrastructure",
+    "validate_config",
+    "read_state",
+    "detect_drift",
+    "enforce_policy",
+]
+
+
+def get_langchain_tools(toolkit: TerraformAgentToolkit) -> List[Tool]:
+    """Return LangChain Tool objects wrapping the toolkit methods."""
+    tools = []
+    for name in TOOL_METHODS:
+        method = getattr(toolkit, name)
+        tools.append(
+            Tool(
+                name=name,
+                func=method,
+                description=name.replace("_", " "),
+            )
+        )
+    return tools

--- a/terraform_agent_toolkit/toolkit.py
+++ b/terraform_agent_toolkit/toolkit.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import List, Dict, Optional
+
+from .core import run_terraform_command
+from .exceptions import ActionNotAllowedError
+
+
+class TerraformAgentToolkit:
+    def __init__(
+        self,
+        working_dir: str,
+        allowed_actions: List[str],
+        require_confirmation_for_apply: bool = True,
+        tf_cloud: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.working_dir = working_dir
+        self.allowed_actions = set(allowed_actions)
+        self.require_confirmation_for_apply = require_confirmation_for_apply
+        self.tf_cloud = tf_cloud or {}
+
+    # --------------------- internal helpers ---------------------
+    def _ensure_allowed(self, action: str) -> None:
+        if action not in self.allowed_actions:
+            raise ActionNotAllowedError(f"Action '{action}' is not allowed")
+
+    def _env(self) -> Dict[str, str]:
+        env = None
+        if self.tf_cloud:
+            env = {
+                **{k: v for k, v in self.tf_cloud.items()},
+            }
+        return env
+
+    # ------------------------- tools ---------------------------
+    def plan_infrastructure(self) -> Dict[str, object]:
+        self._ensure_allowed("plan_infrastructure")
+        env = self._env()
+        init_result = run_terraform_command(["terraform", "init", "-input=false"], self.working_dir, env)
+        if not init_result["success"]:
+            return {"success": False, "summary": init_result["summary"]}
+        plan_result = run_terraform_command(["terraform", "plan", "-no-color"], self.working_dir, env)
+        return {"success": plan_result["success"], "summary": plan_result["summary"]}
+
+    def apply_infrastructure(self, *, confirm: bool = False) -> Dict[str, object]:
+        self._ensure_allowed("apply_infrastructure")
+        if self.require_confirmation_for_apply and not confirm:
+            return {"success": False, "error": "CONFIRMATION_REQUIRED"}
+        env = self._env()
+        init_result = run_terraform_command(["terraform", "init", "-input=false"], self.working_dir, env)
+        if not init_result["success"]:
+            return {"success": False, "summary": init_result["summary"]}
+        apply_result = run_terraform_command([
+            "terraform",
+            "apply",
+            "-auto-approve",
+            "-no-color",
+        ], self.working_dir, env)
+        return {"success": apply_result["success"], "summary": apply_result["summary"]}
+
+    def validate_config(self) -> Dict[str, object]:
+        self._ensure_allowed("validate_config")
+        env = self._env()
+        init_result = run_terraform_command(["terraform", "init", "-input=false"], self.working_dir, env)
+        if not init_result["success"]:
+            return {"success": False, "summary": init_result["summary"]}
+        val_result = run_terraform_command(["terraform", "validate"], self.working_dir, env)
+        return {"success": val_result["success"], "summary": val_result["summary"]}
+
+    def read_state(self) -> Dict[str, object]:
+        self._ensure_allowed("read_state")
+        env = self._env()
+        show_result = run_terraform_command(["terraform", "show", "-no-color"], self.working_dir, env)
+        return {"success": show_result["success"], "summary": show_result["summary"]}
+
+    def detect_drift(self) -> Dict[str, object]:
+        self._ensure_allowed("detect_drift")
+        env = self._env()
+        init_result = run_terraform_command(["terraform", "init", "-input=false"], self.working_dir, env)
+        if not init_result["success"]:
+            return {"success": False, "summary": init_result["summary"]}
+        drift_result = run_terraform_command(["terraform", "plan", "-detailed-exitcode", "-no-color"], self.working_dir, env)
+        success = drift_result["returncode"] in (0, 2)
+        return {"success": success, "summary": drift_result["summary"]}
+
+    def enforce_policy(self) -> Dict[str, object]:
+        self._ensure_allowed("enforce_policy")
+        env = self._env()
+        init_result = run_terraform_command(["terraform", "init", "-input=false"], self.working_dir, env)
+        if not init_result["success"]:
+            return {"success": False, "summary": init_result["summary"]}
+        policy_result = run_terraform_command(["terraform", "validate"], self.working_dir, env)
+        return {"success": policy_result["success"], "summary": policy_result["summary"]}
+
+    # --------------------- openai interface --------------------
+    def get_tools(self) -> List[Dict[str, object]]:
+        """Return OpenAI function specs for all tools."""
+        tools = [
+            {
+                "name": "plan_infrastructure",
+                "description": "Generate a Terraform plan",
+                "parameters": {},
+            },
+            {
+                "name": "apply_infrastructure",
+                "description": "Apply Terraform changes",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "confirm": {"type": "boolean"},
+                    },
+                    "required": [],
+                },
+            },
+            {
+                "name": "validate_config",
+                "description": "Validate Terraform configuration",
+                "parameters": {},
+            },
+            {
+                "name": "read_state",
+                "description": "Read Terraform state",
+                "parameters": {},
+            },
+            {
+                "name": "detect_drift",
+                "description": "Detect infrastructure drift",
+                "parameters": {},
+            },
+            {
+                "name": "enforce_policy",
+                "description": "Enforce policy on Terraform configuration",
+                "parameters": {},
+            },
+        ]
+        return tools

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,0 +1,54 @@
+import subprocess
+from terraform_agent_toolkit.toolkit import TerraformAgentToolkit
+from terraform_agent_toolkit.exceptions import ActionNotAllowedError
+
+
+class DummyProcess:
+    def __init__(self, returncode=0, stdout="ok", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def fake_run_factory(calls):
+    def fake_run(cmd, cwd=None, env=None, capture_output=True, text=True):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="success", stderr="")
+    return fake_run
+
+
+def test_plan_apply_happy_path(monkeypatch):
+    calls = []
+    monkeypatch.setattr(subprocess, "run", fake_run_factory(calls))
+    tk = TerraformAgentToolkit(
+        working_dir="/tmp",
+        allowed_actions=["plan_infrastructure", "apply_infrastructure"],
+    )
+    res_plan = tk.plan_infrastructure()
+    assert res_plan["success"]
+    res_apply = tk.apply_infrastructure(confirm=True)
+    assert res_apply["success"]
+    assert len(calls) == 4  # init+plan+init+apply
+
+
+def test_confirmation_gate(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", fake_run_factory([]))
+    tk = TerraformAgentToolkit(
+        working_dir="/tmp",
+        allowed_actions=["apply_infrastructure"],
+        require_confirmation_for_apply=True,
+    )
+    res = tk.apply_infrastructure()
+    assert not res["success"]
+    assert res["error"] == "CONFIRMATION_REQUIRED"
+
+
+def test_disallowed_action(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", fake_run_factory([]))
+    tk = TerraformAgentToolkit(working_dir="/tmp", allowed_actions=[])
+    try:
+        tk.plan_infrastructure()
+    except ActionNotAllowedError:
+        pass
+    else:
+        assert False, "expected ActionNotAllowedError"


### PR DESCRIPTION
## Summary
- add TerraformAgentToolkit package for Terraform CLI management
- provide tools with action gating and confirmation gating
- include LangChain adapter and tests
- set up minimal pyproject and README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*